### PR TITLE
Fix model names and HTML in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -15,12 +15,12 @@ You'll find the models (weights) on [HuggingFace](https://huggingface.co/ibm-gra
 <table>
   <tr>
     <td><a href="https://github.com/ibm-granite/granite-4.1-language-models">Granite 4.1 Language Models</a></td>
-    <td><a href="https://github.com/ibm-granite/granite-vision-models">Granite 4.1 Vision Models</a></td>
-       <td><a href="https://github.com/ibm-granite/granite-speech-models">Granite 4.1 Speech Models</a></td>
+    <td><a href="https://github.com/ibm-granite/granite-vision-models">Granite Vision Models</a></td>
+       <td><a href="https://github.com/ibm-granite/granite-speech-models">Granite Speech Models</a></td>
   </tr>
   <tr>
       <td><a href="https://github.com/ibm-granite/granite-embedding-models">Granite Embedding Models</a></td>
-    <td><a href="https://github.com/ibm-granite/granite-guardian">Granite 4.1 Guardian Models</a></td>  
+    <td><a href="https://github.com/ibm-granite/granite-guardian">Granite Guardian Models</a></td>  
         <td><a href="https://github.com/ibm-granite/granite-tsfm">Granite Time Series Foundation Models</a></td>
   </tr>
    <tr>
@@ -36,7 +36,7 @@ You'll find the models (weights) on [HuggingFace](https://huggingface.co/ibm-gra
 <table>
   <tr>
    <td><b>Trust</b></td> 
-   <td><a href="https://github.com/ibm-granite/granite.trust.policy-tools">Policy Tools<td>
+   <td><a href="https://github.com/ibm-granite/granite.trust.policy-tools">Policy Tools</td>
   </tr>
   <tr>
    <td><b>Debug</b></td> 


### PR DESCRIPTION
## Summary
- Removes version numbers from vision, speech, and guardian model names for consistency
- Fixes unclosed `<td>` tag in the Policy Tools table row

## Test plan
- [ ] Verify README renders correctly on GitHub